### PR TITLE
Minor updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Examples:
 ```
 git clone https://github.com/nalinigans/GenomicsDB-Install.git
 cd GenomicsDB-Install
-docker build --build-arg os=ubuntu --build-arg branch=develop --build-arg install_dir=/home/$USER -t genomicsdb:build . 
+docker build --build-arg os=ubuntu:trusty --build-arg branch=develop --build-arg install_dir=/home/$USER -t genomicsdb:build . 
 ```
 
 To run and enter the bash shell:

--- a/scripts/install_genomicsdb.sh
+++ b/scripts/install_genomicsdb.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 GENOMICSDB_USER=${1:-genomicsdb}
 GENOMICSDB_BRANCH=${2:-develop}
 GENOMICSDB_INSTALL_DIR=${3:-/usr/local}

--- a/scripts/prereqs/install_centos_prereqs.sh
+++ b/scripts/prereqs/install_centos_prereqs.sh
@@ -1,11 +1,12 @@
 #!/bin/bash
 
+set -e
+
 install_devtoolset() {
 	echo "Installing devtoolset"
 	yum install -y centos-release-scl &&
-	yum-config-manager --enable rhel-server-rhscl-7-rpms &&
-	yum install -y devtoolset-6 &&
-	echo "source /opt/rh/devtoolset-6/enable" >> $PREREQS_ENV
+	yum install -y devtoolset-7 &&
+	echo "source /opt/rh/devtoolset-7/enable" >> $PREREQS_ENV
 }
 
 install_openjdk() {

--- a/scripts/prereqs/install_prereqs.sh
+++ b/scripts/prereqs/install_prereqs.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 PREREQS_ENV=/etc/profile.d/prereqs.sh
 touch $PREREQS_ENV
 

--- a/scripts/prereqs/install_ubuntu_prereqs.sh
+++ b/scripts/prereqs/install_ubuntu_prereqs.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 install_openjdk8() {
 	apt-get -y install openjdk-8-jdk icedtea-plugin &&
 	apt-get update -q &&
@@ -8,6 +10,12 @@ install_openjdk8() {
 	source jdk_switcher/jdk_switcher.sh && jdk_switcher use openjdk8 &&
 	echo "export JAVA_HOME=$JAVA_HOME" >> $PREREQS_ENV &&
 	popd
+}
+
+install_cmake3() {
+        wget -nv https://github.com/Kitware/CMake/releases/download/v3.4.0/cmake-3.4.0-Linux-x86_64.sh -P /tmp &&
+        chmod +x /tmp/cmake-3.4.0-Linux-x86_64.sh &&
+        /tmp/cmake-3.4.0-Linux-x86_64.sh --prefix=/usr/local --skip-license
 }
 
 install_prerequisites_ubuntu() {
@@ -39,5 +47,6 @@ install_prerequisites_ubuntu() {
 	install_openjdk8 &&
 	apt-get clean &&
 	apt-get purge -y &&
+        install_cmake3 &&
 	rm -rf /var/lib/apt/lists*
 }


### PR DESCRIPTION
- Had to push to devtoolset-7 for centos:7 to work
- ubuntu:trusty needed cmake3 for build distributable
- added 'set -e' for the scripts so that the script fails when a step fails. This should make it easier to debug so we don't have to hunt all the way back to some failure at the beginning.
- small doc update to specify `trusty` for ubuntu...doesn't work with latest versions

I haven't tested all possible variants here, of course...so hopefully this doesn't break other stuff!